### PR TITLE
Update on databrickslabs/terraform-provider-databricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠️ Please prefer using the actively maintained [Databricks (labs) Terraform Provider](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs).
+
 Databricks Terraform Provider
 =============================
 


### PR DESCRIPTION
Add link to https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs